### PR TITLE
feat: Added Dedicated Clickhouse Node Pool for Larger Deployments

### DIFF
--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -122,62 +122,6 @@ resource "google_container_node_pool" "default" {
   }
 }
 
-resource "google_container_node_pool" "app_node_pool" {
-  count      = var.enable_app_node_pool ? 1 : 0
-  name       = "${var.deployment_name}app-node-pool"
-  cluster    = google_container_cluster.default.id
-  node_count = var.initial_node_count
-
-  node_config {
-    image_type      = "COS_CONTAINERD"
-    machine_type    = var.app_np_machine_type
-    disk_size_gb    = var.disk_size_gb
-    disk_type       = var.disk_type
-    service_account = resource.google_service_account.gke_service_account.email
-
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
-    shielded_instance_config {
-      enable_secure_boot = true
-      enable_integrity_monitoring = true
-    }
-    # Define the labels for the nodes
-    labels = {
-      default-node-pool = true
-    }
-    metadata = {
-      disable-legacy-endpoints = "true"
-    }
-  }
-
-  autoscaling {
-    min_node_count = 1
-    max_node_count = 2
-    location_policy = "ANY"
-  }
-
-  management {
-    auto_upgrade = true
-    auto_repair  = true
-  }
-
-  upgrade_settings {
-    max_surge       = 1
-    max_unavailable = 1
-  }
-
-  lifecycle {
-    ignore_changes = [
-      location,
-    ]
-    create_before_destroy = true
-  }
-}
-
 resource "google_container_node_pool" "ch_node_pool" {
   count      = var.enable_ch_node_pool ? 1 : 0
   name       = "${var.deployment_name}ch-node-pool"

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -121,3 +121,121 @@ resource "google_container_node_pool" "default" {
     create_before_destroy = true
   }
 }
+
+resource "google_container_node_pool" "app_node_pool" {
+  count      = var.enable_app_node_pool ? 1 : 0
+  name       = "${var.deployment_name}app-node-pool"
+  cluster    = google_container_cluster.default.id
+  node_count = var.initial_node_count
+
+  node_config {
+    image_type      = "COS_CONTAINERD"
+    machine_type    = var.app_np_machine_type
+    disk_size_gb    = var.disk_size_gb
+    disk_type       = var.disk_type
+    service_account = resource.google_service_account.gke_service_account.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+    shielded_instance_config {
+      enable_secure_boot = true
+      enable_integrity_monitoring = true
+    }
+    # Define the labels for the nodes
+    labels = {
+      default-node-pool = true
+    }
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+
+  autoscaling {
+    min_node_count = 1
+    max_node_count = 2
+    location_policy = "ANY"
+  }
+
+  management {
+    auto_upgrade = true
+    auto_repair  = true
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      location,
+    ]
+    create_before_destroy = true
+  }
+}
+
+resource "google_container_node_pool" "ch_node_pool" {
+  count      = var.enable_ch_node_pool ? 1 : 0
+  name       = "${var.deployment_name}ch-node-pool"
+  cluster    = google_container_cluster.default.id
+  node_count = var.initial_node_count
+
+  node_config {
+    image_type      = "COS_CONTAINERD"
+    machine_type    = var.ch_machine_type
+    disk_size_gb    = var.disk_size_gb
+    disk_type       = var.disk_type
+    service_account = resource.google_service_account.gke_service_account.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+    shielded_instance_config {
+      enable_secure_boot = true
+      enable_integrity_monitoring = true
+    }
+    # Define the labels for the nodes
+    labels = {
+      default-node-pool = false
+    }
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+    taint {
+      key    = "clickhouse"
+      value  = "reserved"
+      effect = "NO_SCHEDULE"
+    }
+  }
+
+  autoscaling {
+    min_node_count = 1
+    max_node_count = 1
+    location_policy = "ANY"
+  }
+
+  management {
+    auto_upgrade = true
+    auto_repair  = true
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      location,
+    ]
+    create_before_destroy = true
+  }
+}
+

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -59,7 +59,7 @@ variable "initial_node_count" {
 
 variable "machine_type" {
   type        = string
-  default     = "e2-highmem-16"
+  default     = "e2-highmem-8"
   description = "The machine type for the GKE cluster nodes"
 }
 

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -59,7 +59,7 @@ variable "initial_node_count" {
 
 variable "machine_type" {
   type        = string
-  default     = "e2-highmem-8"
+  default     = "e2-highmem-16"
   description = "The machine type for the GKE cluster nodes"
 }
 
@@ -75,22 +75,10 @@ variable "disk_type" {
   description = "The disk type for the GKE cluster nodes"
 }
 
-variable "enable_app_node_pool" {
-  description = "Whether to enable the app node pool"
-  type        = bool
-  default     = false
-}
-
 variable "enable_ch_node_pool" {
   description = "Whether to enable the ch node pool"
   type        = bool
   default     = false
-}
-
-variable "app_np_machine_type" {
-  type        = string
-  default     = "e2-highmem-16"
-  description = "The machine type for the app GKE cluster nodes"
 }
 
 variable "ch_machine_type" {

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -74,3 +74,27 @@ variable "disk_type" {
   default     = "pd-standard"
   description = "The disk type for the GKE cluster nodes"
 }
+
+variable "enable_app_node_pool" {
+  description = "Whether to enable the app node pool"
+  type        = bool
+  default     = false
+}
+
+variable "enable_ch_node_pool" {
+  description = "Whether to enable the ch node pool"
+  type        = bool
+  default     = false
+}
+
+variable "app_np_machine_type" {
+  type        = string
+  default     = "e2-highmem-16"
+  description = "The machine type for the app GKE cluster nodes"
+}
+
+variable "ch_machine_type" {
+  type        = string
+  default     = "n2-standard-8"
+  description = "The machine type for the ch GKE cluster nodes"
+}


### PR DESCRIPTION
- added two new container node pools
- second one for clickhouse has taint applied

notes: unsure about appropriate sizing so as of now I have reused variables from the "default" container node pool related to disk size and disk type

my understanding is we have a label "default-node-pool" = true however it may not actually be functioning as a "default" node pool in the traditional sense as I don't see the use of this label in nodeSelector or anywhere else, perhaps since we only have one it is becoming "default". Now that we have more added should we use any other means to determine scheduling or just assume this will be sort of a "spillover" or eventually one that will replace the original `e2-highmem-8` ? 
