### PR TITLE
fix: Set restricted CIDR blocks for k8s control plane

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,16 +81,17 @@ module "database" {
 module "gke" {
   source = "./modules/gke"
 
-  project_id            = var.project_id
-  deployment_name       = var.deployment_name
-  vpc_id                = local.vpc_id
-  subnetwork            = local.vpc_subnetwork
-  azs                   = local.azs
-  disk_size_gb          = var.default_node_disk_size
-  vpc_master_cidr_block = var.vpc_master_cidr_block
-  machine_type          = var.machine_type
-  enable_ch_node_pool   = var.enable_ch_node_pool
-  ch_machine_type       = var.ch_machine_type
+  project_id              = var.project_id
+  deployment_name         = var.deployment_name
+  vpc_id                  = local.vpc_id
+  subnetwork              = local.vpc_subnetwork
+  azs                     = local.azs
+  disk_size_gb            = var.default_node_disk_size
+  vpc_master_cidr_block   = var.vpc_master_cidr_block
+  machine_type            = var.machine_type
+  enable_ch_node_pool     = var.enable_ch_node_pool
+  ch_machine_type         = var.ch_machine_type
+  k8s_authorized_networks = var.k8s_authorized_networks
 }
 
 module "load_balancer" {

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -30,6 +30,16 @@ resource "google_container_cluster" "default" {
     master_ipv4_cidr_block  = var.vpc_master_cidr_block
   }
 
+  master_authorized_networks_config {
+    dynamic "cidr_blocks" {
+      for_each = var.k8s_authorized_networks
+      content {
+        cidr_block = cidr_blocks.key
+        display_name = cidr_blocks.value
+      }
+    }
+  }
+
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = var.vpc_secondary_ranges_name_pods
     services_ipv4_cidr_block = var.vpc_secondary_ranges_name_services

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -86,3 +86,9 @@ variable "ch_machine_type" {
   default     = "n2-standard-8"
   description = "The machine type for the ch GKE cluster nodes"
 }
+
+variable "k8s_authorized_networks" {
+  type        = map(string)
+  default     = {"0.0.0.0/0": "public"}
+  description = "Map of CIDR blocks that are able to connect to the K8S control plane"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -463,3 +463,9 @@ variable "ch_machine_type" {
   default     = "n2-standard-8"
   description = "The machine type for the ch GKE cluster nodes"
 }
+
+variable "k8s_authorized_networks" {
+  type        = map(string)
+  default     = {"0.0.0.0/0": "public"}
+  description = "Map of CIDR blocks that are able to connect to the K8S control plane"
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix

## Description

Adds capability to filter / whitelist IP CIDR ranges that are able to contact the k8s control plane.