### PR TITLE
fix: Disable auto-upgrade nodes by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ override.tf.json
 terraform.rc
 
 .idea/
-
+.history/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See this file for notable changes between versions.
 
+### [1.2.4](https://github.com/datafold/terraform-google-datafold/compare/v1.2.3...v1.2.4) (2024-08-19)
+
+* Disable auto-upgrade of nodes ([bc087ae](https://github.com/datafold/terraform-google-datafold/commit/bc087ae5fbbe1b0471295fea462b11f6c1f6c58a))
+
 ### [1.2.3](https://github.com/datafold/terraform-google-datafold/compare/v1.2.2...v1.2.3) (2024-06-26)
 
 

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,9 @@ module "gke" {
   enable_ch_node_pool     = var.enable_ch_node_pool
   ch_machine_type         = var.ch_machine_type
   k8s_authorized_networks = var.k8s_authorized_networks
+  k8s_cluster_version     = var.k8s_cluster_version
+  k8s_node_version        = var.k8s_node_version
+  k8s_node_auto_upgrade   = var.k8s_node_auto_upgrade
 }
 
 module "load_balancer" {

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -14,8 +14,20 @@ variable "azs" {
 
 variable "k8s_cluster_version" {
   type        = string
-  default     = "1.27"
+  default     = "1.28.11"
   description = "The version of Kubernetes to use for the GKE cluster. The patch/GKE specific version will be found automatically."
+}
+
+variable "k8s_node_auto_upgrade" {
+  type        = bool
+  default     = false
+  description = "Whether to enable auto-upgrade for the GKE cluster nodes"
+}
+
+variable "k8s_node_version" {
+  type        = string
+  default     = "1.28.11"
+  description = "The version of the nodes"
 }
 
 variable "deployment_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -469,3 +469,21 @@ variable "k8s_authorized_networks" {
   default     = {"0.0.0.0/0": "public"}
   description = "Map of CIDR blocks that are able to connect to the K8S control plane"
 }
+
+variable "k8s_cluster_version" {
+  type        = string
+  default     = "1.28.11"
+  description = "The version of Kubernetes to use for the GKE cluster. The patch/GKE specific version will be found automatically."
+}
+
+variable "k8s_node_auto_upgrade" {
+  type        = bool
+  default     = false
+  description = "Whether to enable auto-upgrade for the GKE cluster nodes"
+}
+
+variable "k8s_node_version" {
+  type        = string
+  default     = "1.28.11"
+  description = "The version of the nodes"
+}


### PR DESCRIPTION
## Description

Auto-upgrade of the nodes/cluster disrupts the application significantly. Opt for a more manual solution where we choose when we have downtime.
