### PR TITLE
fix: Add ability to set release channel to None for cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ See this file for notable changes between versions.
 
 * Disable auto-upgrade nodes by default ([bc087ae](https://github.com/datafold/terraform-google-datafold/commit/bc087ae5fbbe1b0471295fea462b11f6c1f6c58a))
 
-### [1.2.4](https://github.com/datafold/terraform-google-datafold/compare/v1.2.3...v1.2.4) (2024-08-19)
-
-* Disable auto-upgrade of nodes ([bc087ae](https://github.com/datafold/terraform-google-datafold/commit/bc087ae5fbbe1b0471295fea462b11f6c1f6c58a))
-
 ### [1.2.3](https://github.com/datafold/terraform-google-datafold/compare/v1.2.2...v1.2.3) (2024-06-26)
 
 

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -20,7 +20,7 @@ resource "google_container_cluster" "default" {
   project            = var.project_id
   network            = var.vpc_id
   subnetwork         = var.subnetwork
-  master_version = data.google_container_engine_versions.cluster.latest_master_version
+  min_master_version = data.google_container_engine_versions.cluster.latest_master_version
 
   networking_mode = "VPC_NATIVE"
 
@@ -53,7 +53,7 @@ resource "google_container_cluster" "default" {
   }
 
   release_channel {
-    channel = "STABLE"
+    channel = var.k8s_node_auto_upgrade ? "STABLE" : "UNSPECIFIED"
   }
 
   node_config {


### PR DESCRIPTION
In order to make the nodes not auto-scale, the cluster can't have a release channel set. Terraform won't remove the release channel when you remove the `release_channel` block (or make it dynamic). You need to explicitly set to `UNSPECIFIED`.

`master_version` is not configurable.