### PR TITLE
fix: Enable network policies

### DIFF
--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -72,6 +72,17 @@ resource "google_container_cluster" "default" {
     }
   }
 
+  network_policy {
+    enabled  = true
+    provider = "CALICO"
+  }
+
+  addons_config {
+    network_policy_config {
+      disabled = false
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       node_config,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix

## Description

By default the network policies are not enabled. It is good practice to have these enabled, should we need these in the future. 
