### PR TITLE
fix: Add capability to specify spot

### DIFF
--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -227,6 +227,7 @@ resource "google_container_node_pool" "custom_node_pools" {
     disk_size_gb    = each.value.disk_size_gb
     disk_type       = each.value.disk_type
     service_account = resource.google_service_account.gke_service_account.email
+    spot            = each.value.spot
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
@@ -237,6 +238,9 @@ resource "google_container_node_pool" "custom_node_pools" {
     shielded_instance_config {
       enable_secure_boot = true
       enable_integrity_monitoring = true
+    }
+    gvnic {
+      enabled = true
     }
     # Define the labels for the nodes
     labels = {

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -113,6 +113,7 @@ variable "custom_node_pools" {
     machine_type = string
     disk_size_gb = number
     disk_type = string
+    spot = bool
     taints = list(object({
       key    = string
       value  = string

--- a/variables.tf
+++ b/variables.tf
@@ -466,6 +466,7 @@ variable "custom_node_pools" {
     machine_type = string
     disk_size_gb = number
     disk_type = string
+    spot = bool
     taints = list(object({
       key    = string
       value  = string


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix

## Description

Extra nodepools by default need gvnic enabled and have the capability to deploy as spot.
