### PR TITLE
fix: Do not scale on terraform apply

### DIFF
--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -146,6 +146,7 @@ resource "google_container_node_pool" "default" {
   lifecycle {
     ignore_changes = [
       location,
+      node_count,
     ]
     create_before_destroy = true
   }
@@ -208,6 +209,7 @@ resource "google_container_node_pool" "ch_node_pool" {
   lifecycle {
     ignore_changes = [
       location,
+      node_count,
     ]
     create_before_destroy = true
   }
@@ -276,6 +278,7 @@ resource "google_container_node_pool" "custom_node_pools" {
   lifecycle {
     ignore_changes = [
       location,
+      node_count,
     ]
     create_before_destroy = true
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix

## Description

Node pools are resized because the node_count can be a different number. We should ignore that, because workloads can be force interrupted because of it.