### PR TITLE
fix: Make 4 default max size

### DIFF
--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -155,7 +155,7 @@ resource "google_container_node_pool" "default" {
 
   autoscaling {
     min_node_count = 1
-    max_node_count = 2
+    max_node_count = var.max_node_count
     location_policy = "ANY"
   }
 

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -92,6 +92,12 @@ variable "initial_node_count" {
   description = "The initial number of nodes for each node pool in the GKE cluster"
 }
 
+variable "max_node_count" {
+  type        = number
+  default     = 4
+  description = "The maximum number of nodes in the cluster"
+}
+
 variable "machine_type" {
   type        = string
   default     = "e2-highmem-8"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

Specify one of the following as the first element in the title:

- fix: A bug fix

## Description

4 is the new default size for the node pool due to Vertical Pod Autoscaling project.